### PR TITLE
Add platform check to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ include(SMTG_VST3_SDK)
 
 project(min-vst-host)
 
+if(NOT (CMAKE_SYSTEM_NAME STREQUAL "Linux"))
+  message(FATAL_ERROR "This project supports only Linux platforms.")
+endif()
+
 set(VST_SDK TRUE)
 set(SDK_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/libs/vst3sdk")
 add_subdirectory(${SDK_ROOT}/pluginterfaces)


### PR DESCRIPTION
## Summary
- stop the build with a fatal error when not running on Linux

## Testing
- `cmake -S . -B build` *(fails: include could not find SMTG_VST3_SDK and unknown command smtg_setup_platform_toolset)*

------
https://chatgpt.com/codex/tasks/task_e_686a2388808483268ccb2bef36021dee