### PR TITLE
Extract plugin loader into its own class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ smtg_setup_symbol_visibility()
 set(min_vst_host_sources
   ${SDK_ROOT}/public.sdk/source/vst/hosting/plugprovider.cpp
   ${SDK_ROOT}/public.sdk/source/vst/hosting/plugprovider.h
+  source/pluginloader.cpp
+  source/pluginloader.h
   source/editorhost.cpp
   source/editorhost.h
   source/platform/appinit.h

--- a/source/editorhost.cpp
+++ b/source/editorhost.cpp
@@ -139,48 +139,7 @@ App::~App() noexcept { terminate(); }
 //------------------------------------------------------------------------
 void App::openEditor(const std::string &path,
                      VST3::Optional<VST3::UID> effectID, uint32 flags) {
-  std::string error;
-  module = VST3::Hosting::Module::create(path, error);
-  if (!module) {
-    std::string reason = "Could not create Module for file:";
-    reason += path;
-    reason += "\nError: ";
-    reason += error;
-    IPlatform::instance().kill(-1, reason);
-  }
-
-  auto factory = module->getFactory();
-  if (auto factoryHostContext = IPlatform::instance().getPluginFactoryContext())
-    factory.setHostContext(factoryHostContext);
-  for (auto &classInfo : factory.classInfos()) {
-    if (classInfo.category() == kVstAudioEffectClass) {
-      if (effectID) {
-        if (*effectID != classInfo.ID())
-          continue;
-      }
-      plugProvider = owned(new PlugProvider(factory, classInfo, true));
-      if (plugProvider->initialize() == false)
-        plugProvider = nullptr;
-      break;
-    }
-  }
-  if (!plugProvider) {
-    if (effectID)
-      error = "No VST3 Audio Module Class with UID " + effectID->toString() +
-              " found in file ";
-    else
-      error = "No VST3 Audio Module Class found in file ";
-    error += path;
-    IPlatform::instance().kill(-1, error);
-  }
-
-  auto editController = plugProvider->getController();
-  if (!editController) {
-    error =
-        "No EditController found (needed for allowing editor) in file " + path;
-    IPlatform::instance().kill(-1, error);
-  }
-  editController->release(); // plugProvider does an addRef
+  auto editController = pluginLoader.load(path, std::move(effectID));
 
   if (flags & kSetComponentHandler) {
     SMTG_DBPRT0("setComponentHandler is used\n");
@@ -269,8 +228,7 @@ void App::terminate() {
   if (windowController)
     windowController->closePlugView();
   windowController.reset();
-  plugProvider.reset();
-  module.reset();
+  pluginLoader.unload();
   PluginContextFactory::instance().setPluginContext(nullptr);
 }
 

--- a/source/pluginloader.h
+++ b/source/pluginloader.h
@@ -30,41 +30,32 @@
 #pragma once
 
 #include "public.sdk/source/vst/hosting/hostclasses.h"
-#include "source/pluginloader.h"
+#include "public.sdk/source/vst/hosting/module.h"
+#include "public.sdk/source/vst/hosting/plugprovider.h"
 #include "public.sdk/source/vst/utility/optional.h"
-#include "source/platform/iapplication.h"
-#include "source/platform/iwindow.h"
 
 //------------------------------------------------------------------------
 namespace Steinberg {
 namespace Vst {
 namespace EditorHost {
 
-class WindowController;
-
 //------------------------------------------------------------------------
-class App : public IApplication {
+class PluginLoader {
 public:
-  ~App() noexcept override;
-  void init(const std::vector<std::string> &cmdArgs) override;
-  void terminate() override;
+  ~PluginLoader() noexcept;
+
+  IEditController *load(const std::string &path,
+                        VST3::Optional<VST3::UID> effectID);
+  void unload();
 
 private:
-  enum OpenFlags {
-    kSetComponentHandler = 1 << 0,
-    kSecondWindow = 1 << 1,
-  };
-  void openEditor(const std::string &path, VST3::Optional<VST3::UID> effectID,
-                  uint32 flags);
-  void createViewAndShow(IEditController *controller);
-
-  PluginLoader pluginLoader;
-  Vst::HostApplication pluginContext;
-  WindowPtr window;
-  std::shared_ptr<WindowController> windowController;
+  VST3::Hosting::Module::Ptr module{nullptr};
+  IPtr<PlugProvider> plugProvider{nullptr};
 };
 
 //------------------------------------------------------------------------
 } // namespace EditorHost
 } // namespace Vst
 } // namespace Steinberg
+
+


### PR DESCRIPTION
## Summary
- add `PluginLoader` class to encapsulate plug‑in loading
- use `PluginLoader` from `App::openEditor`
- keep only window creation in `openEditor`
- reference new sources in the build

## Testing
- `pre-commit` *(fails: error 403 cloning dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686b76821cd48326b278532703e8ad1a